### PR TITLE
bug fixes, keyword is 'operator' instead of 'operator_name'

### DIFF
--- a/synmax/common/model.py
+++ b/synmax/common/model.py
@@ -11,7 +11,7 @@ class PayloadModelBase:
     state_code: str = None
     region: str = None
     sub_region: str = None
-    operator_name: str = None
+    operator: str = None
 
     # fetch_all = True
 

--- a/synmax/hyperion/hyperion_client.py
+++ b/synmax/hyperion/hyperion_client.py
@@ -20,7 +20,7 @@ class ApiPayload(PayloadModelBase):
             "state_code": self.state_code,
             "region": self.region,
             "sub_region": self.sub_region,
-            "operator_name": self.operator_name,
+            "operator": self.operator,
             "production_month": self.production_month,
 
             "pagination": {


### PR DESCRIPTION
Hi Deepa, 
please check if changes to Payload Class are fine. I accidentally called the parameter 'operator_name' instead of 'operator'. But the API Docs say that 'operator' is a filter for the endpoints. 

Please update the package version number once approved. 